### PR TITLE
Removes apache2.pid before starting apache

### DIFF
--- a/bespin-web/scripts/start-apache.sh
+++ b/bespin-web/scripts/start-apache.sh
@@ -6,4 +6,7 @@ python manage.py migrate
 create-lando-user.sh
 load-sample-data.sh
 
+# Apache gets grumpy about PID files pre-existing
+rm -f /var/run/apache2/apache2.pid
+
 apachectl -DFOREGROUND


### PR DESCRIPTION
Hasn't been a problem here yet, but restarting the container could fail if this file already exists