### PR TITLE
Removes bespin-ui from docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 bespin-webapp-docker
 ====================
 
-Dockerfile and docker-compose script for running bespin-api and bespin-ui
+Dockerfile and docker-compose script for running bespin-api with bespin-ui
 
 # Usage
 
-The Dockerfile contained in web is used to build an image containing the Django (backend) and Ember (frontend) applications, hosted by a single Apache httpd server.
+The Dockerfile contained in web is used to build an image containing the Django (backend), hosted by Apache httpd.
+The Ember frontend application is not included in the image, but should be downloaded from its release and mounted at `/srv/ui/`
 
 It also includes a docker-compose file that can deploy the image and its backing Postgres database
 
 1. Create files `bespin-database.env` and `bespin-web.env`, based on the `.sample` files.
-2. Create self signed certificates: 
+2. Create self signed certificates:
 ```
 mkdir certs
 cd certs

--- a/bespin-web/Dockerfile
+++ b/bespin-web/Dockerfile
@@ -23,16 +23,12 @@ RUN a2dissite 000-default
 RUN a2enmod rewrite
 RUN a2enmod ssl
 
-# Setup scripts (including get-bespin-ui-url.py)
 COPY scripts /scripts
 
-# Install the bespin UI app somewhere
-ENV BESPIN_UI_ROOT /srv/ui
-RUN mkdir ${BESPIN_UI_ROOT}
-RUN echo "Downloading bespin-ui from $(/scripts/get-bespin-ui-url.py)"
-RUN curl -SL `/scripts/get-bespin-ui-url.py` | tar -xzC $BESPIN_UI_ROOT
+# Mark /srv/ui as a volume
 
-# set the command to start apache
+VOLUME /srv/ui
+COPY index.html /srv/ui/index.html
 
 EXPOSE 80
 EXPOSE 443
@@ -40,5 +36,6 @@ EXPOSE 443
 # Add /scripts to the PATH
 ENV PATH ${PATH}:/scripts/
 
+# set the command to start apache
 ENTRYPOINT ["/scripts/wait-for-postgres.sh"]
 CMD ["/scripts/start-apache.sh"]

--- a/bespin-web/index.html
+++ b/bespin-web/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>bespin-web</title>
+</head>
+<body>
+  This is a placeholder file. You should run this container replacing <strong>/srv/ui</strong> with a built copy of <strong>bespin-ui</strong>
+</body>
+</html>

--- a/bespin-web/scripts/get-bespin-ui-url.py
+++ b/bespin-web/scripts/get-bespin-ui-url.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-import urllib2
-import json
-
-releases_url = 'https://api.github.com/repos/Duke-GCB/bespin-ui/releases/latest'
-
-f = urllib2.urlopen(releases_url)
-print json.loads(f.read())['assets'][0]['browser_download_url']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   bespin-web:
     depends_on:
       - bespin-database
-    image: quay.io/dukegcb/bespin-web
+    image: dukegcb/bespin-web
     ports:
       - "80:80"
       - "443:443"
@@ -20,6 +20,7 @@ services:
       - bespin-database.env # Since the web app needs database credentials
     volumes:
       - ./certs:/etc/external/ssl
+      # - TODO: Add a volume for the bespin-ui
     networks:
       - bespin-web
 volumes:


### PR DESCRIPTION
To switch between production and dev deployments, we’d have to drop in
a different file completely, resulting in multiple containers.
Instead, we simplify by mounting the ui files as a volume

I tested this with the local docker-compose file. When /srv/ui is replaced with a host volume at runtime, the bespin webapp displays. When it is not, the index.html is shown