### PR TITLE
Remove fixture/loading scripts

### DIFF
--- a/bespin-web/scripts/create-group-manager-connection.sh
+++ b/bespin-web/scripts/create-group-manager-connection.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python manage.py creategroupmanagerconnection ${GROUP_MANAGER_ACCOUNT_ID} ${GROUP_MANAGER_PASSWORD}

--- a/bespin-web/scripts/create-lando-connection.sh
+++ b/bespin-web/scripts/create-lando-connection.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python manage.py makelandoconnection ${RABBIT_HOST} ${RABBIT_USERNAME} ${RABBIT_PASSWORD} ${RABBIT_QUEUENAME}

--- a/bespin-web/scripts/create-lando-user.sh
+++ b/bespin-web/scripts/create-lando-user.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python manage.py makeusertoken ${LANDO_DJANGO_USERNAME} ${LANDO_DJANGO_PASSWORD} ${LANDO_DJANGO_TOKEN}

--- a/bespin-web/scripts/create-superuser.sh
+++ b/bespin-web/scripts/create-superuser.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python manage.py createsuperuser

--- a/bespin-web/scripts/load-fixtures.sh
+++ b/bespin-web/scripts/load-fixtures.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python manage.py loaddata ./fixtures/*.yaml /private/fixtures/*.yaml

--- a/bespin-web/scripts/load-fixtures.sh
+++ b/bespin-web/scripts/load-fixtures.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python manage.py loaddata ./fixtures/*.yaml /private/fixtures/*.yaml

--- a/bespin-web/scripts/load-sample-data.sh
+++ b/bespin-web/scripts/load-sample-data.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-python manage.py loaddata example_setup_fixture.yaml

--- a/bespin-web/scripts/start-apache.sh
+++ b/bespin-web/scripts/start-apache.sh
@@ -6,7 +6,6 @@ python manage.py migrate
 create-lando-user.sh
 create-lando-connection.sh
 create-group-manager-connection.sh
-load-sample-data.sh
 
 # Apache gets grumpy about PID files pre-existing
 rm -f /var/run/apache2/apache2.pid

--- a/bespin-web/scripts/start-apache.sh
+++ b/bespin-web/scripts/start-apache.sh
@@ -3,10 +3,6 @@
 # ensure database is migrated before each start of the production application
 python manage.py migrate
 
-create-lando-user.sh
-create-lando-connection.sh
-create-group-manager-connection.sh
-
 # Apache gets grumpy about PID files pre-existing
 rm -f /var/run/apache2/apache2.pid
 


### PR DESCRIPTION
Removes manage.py scripts in favor of putting them into the gcb-ansible deployment.